### PR TITLE
fix: SC_apply() The selected columns were offset.

### DIFF
--- a/src/pyoma2/functions/gen.py
+++ b/src/pyoma2/functions/gen.py
@@ -9,6 +9,7 @@ Dag Pasca
 import logging
 import pickle
 import typing
+import math
 
 import numpy as np
 import pandas as pd
@@ -295,9 +296,7 @@ def SC_apply(Fn, Xi, Phi, ordmin, ordmax, step, err_fn, err_xi, err_phi) -> np.n
 
     # SOFT CONDITIONS
     # STABILITY BETWEEN CONSECUTIVE ORDERS
-    for oo in range(ordmin, ordmax + 1, step):
-        o = int(oo / step - 1)
-
+    for o in range(math.ceil(ordmin / step), math.floor(ordmax / step) + 1):
         f_n = Fn[:, o].reshape(-1, 1)
         xi_n = Xi[:, o].reshape(-1, 1)
         phi_n = Phi[:, o, :]


### PR DESCRIPTION
Hello, I'm a university student using pyOMEA2 for my study and gratefull for your works!

I found a bug in pyoma2.functions.gen.SC_apply().

The following shows what my PR changes the current condition.

--------------------------------------------------------------

import numpy as np
import math

ordmin = 2
ordmax = 28
step = 3

#model orders
arr = np.arange(0, int(ordmax / step + 1)) * step

print(arr)
#[ 0  3  6  9 12 15 18 21 24 27]

#old
for oo in range(ordmin, ordmax + 1, step):
    o = int(oo / step - 1)
    print(arr[o])
#0  0  3  6  9 12 15 18 21

#new
for o in range(math.ceil(ordmin / step), math.floor(ordmax / step) + 1):
    print(arr[o])
#3  6  9 12 15 18 21 24 27

--------------------------------------------------------------------------

import numpy as np
import math

ordmin = 0
ordmax = 5
step = 1

#model orders
arr = np.arange(0, int(ordmax / step + 1)) * step

print(arr)
#[0 1 2 3 4 5]

#old
for oo in range(ordmin, ordmax + 1, step):
    o = int(oo / step - 1)
    print(arr[o])
#5 0 1 2 3 4

#new
for o in range(math.ceil(ordmin / step), math.floor(ordmax / step) + 1):
    print(arr[o])
#0 1 2 3 4 5